### PR TITLE
Add `handle` and HasIO

### DIFF
--- a/eff.ipkg
+++ b/eff.ipkg
@@ -7,7 +7,8 @@ readme     = "README.md"
 license    = "BSD-3 Clause"
 
 sourcedir  = "src"
-depends    = base    >= 0.4.0
+depends    = prelude >= 0.4.0
+           , base    >= 0.4.0
            , tailrec >= 0.1.0
            , freer   >= 0.1.0
 
@@ -18,5 +19,6 @@ modules = Control.Eff
         , Control.Eff.Reader
         , Control.Eff.State
         , Control.Eff.Writer
+        , Control.Eff.Interface
 
         , Data.Union

--- a/src/Control/Eff.idr
+++ b/src/Control/Eff.idr
@@ -6,3 +6,4 @@ import public Control.Eff.Internal
 import public Control.Eff.Reader
 import public Control.Eff.State
 import public Control.Eff.Writer
+import public Control.Eff.Interface

--- a/src/Control/Eff/Interface.idr
+++ b/src/Control/Eff/Interface.idr
@@ -1,0 +1,10 @@
+||| Interact with Standard library
+
+import Control.MonadRec
+import Control.Monad.Free
+import Data.Union
+import Control.Eff.Internal
+
+export
+Has IO fs => HasIO (Free (Union fs)) where
+   liftIO = send

--- a/src/Control/Eff/Internal.idr
+++ b/src/Control/Eff/Internal.idr
@@ -50,6 +50,12 @@ handleRelay fval fcont fr = case toView fr of
     Left y  => assert_total $ lift y >>= handleRelay fval fcont . g
     Right y => assert_total $ fcont y (handleRelay fval fcont . g)
 
+export handle :  (prf : Has f fs)
+              => (forall v . f v -> (resume: v -> Eff (fs - f) b) -> Eff (fs - f) b)
+              -> Eff fs b
+              -> Eff (fs - f) b
+handle fcont fr = handleRelay pure fcont fr
+
 export
 handleRelayS :  (prf : Has f fs)
              => s


### PR DESCRIPTION
For easier use of this library, I added `handle`, which doesn't change the wrapped result type.

Idris cannot yet solve `send $ putStrLn "test"`, so I added `HasIO`.